### PR TITLE
feat: adding dockerfile for docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG platformName=ubuntu
+ARG platformVersion=latest
+FROM ${platformName}:${platformVersion}
+
+ARG version
+ARG configure
+ARG build="--targets=*"
+
+ENV NORM_DIR=/norm-staging
+ENV NORM_BUILD=$NORM_DIR/build
+ENV WAF_CONFIGURE=${configure}
+ENV WAF_BUILD=${build}
+
+ADD ./ ${NORM_DIR}
+
+# Step 1: dependencies
+RUN VERSION=${version} ${NORM_DIR}/docker/setup.sh
+
+# Step 2: build
+RUN cd ${NORM_DIR} && ./waf ${WAF_BUILD}
+
+# Step 3: install
+RUN cd ${NORM_DIR} && ./waf install
+
+# Step 4: expose
+COPY ./docker/run.sh /usr/bin/run-norm-example
+ENTRYPOINT [ "run-norm-example" ]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,37 @@ More info is available in the norp/doc directory, as well as the
 NORP website:  https://www.nrl.navy.mil/itd/ncs/products/norp
 
 
+
+Docker
+======
+A `Dockerfile` is provided to facilitate containerized NORM environment testing. Notable
+build arguments passed to `docker build` will influence how the image is created.
+
+- `platformName` represents the base image name (defaults to `ubuntu`)
+- `platformVersion` represents the tagged version for the base image (defaults to `latest`)
+- `version` is a 1:1 mapping to this repo's tag (defaulst to `v1.5.9`)
+- `configure` is piped to `./waf configure` (defaults to "")
+- `build` is piped to `./waf` (defaults to `--targets=*`)
+
+Example usage:
+
+CentOS7 build
+```
+docker build --build-arg platformName=centos \
+  --build-arg platformVersion=7 \
+  --build-arg="--build-java" \
+  -t norm:centos-1.5.9 .
+```
+
+Running the data send and recv examples:
+```
+# Sender in one terminal
+docker run -it --rm --name norm-send <norm:image> normDataSend
+# Receiver in another terminal
+docker run -it --rm --name norm-recv <norm:image> normDataRecv
+```
+
+
 OTHER FILES:
 ============
 
@@ -114,6 +145,8 @@ NormUserGuide.pdf       - Guide to "norm" demo app usage
 VERSION.TXT             - NORM version history notes
 
 README.md               - this file
+
+docker                  - directory containing docker container support
 
 
 NOTES:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ build arguments passed to `docker build` will influence how the image is created
 
 - `platformName` represents the base image name (defaults to `ubuntu`)
 - `platformVersion` represents the tagged version for the base image (defaults to `latest`)
-- `version` is a 1:1 mapping to this repo's tag (defaulst to `v1.5.9`)
+- `version` is a 1:1 mapping to this repo's tag (defaults to `v1.5.9`)
 - `configure` is piped to `./waf configure` (defaults to "")
 - `build` is piped to `./waf` (defaults to `--targets=*`)
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo Running example $@
+
+exec "$NORM_BUILD/$@"

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -eux
+
+install_debian()
+{
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+       python2.7 \
+       g++ \
+       libxml2-dev \
+       libnetfilter-queue-dev
+
+    ln -s /usr/bin/python2.7 /usr/bin/python
+
+    if [ "$VERSION" != "" ]; then
+        apt-get install -yq git-core
+        cd $NORM_DIR && git checkout $VERSION && git submodule update --checkout --init --force
+    fi
+
+    if [[ "$WAF_CONFIGURE" =~ "java" && -z `which java` ]]; then
+        apt-get install -yq default-jdk-headless
+        export JAVA_HOME=$(readlink -f `which java` | sed 's/\/bin\/java//')
+    fi
+}
+
+install_redhat()
+{
+    yum update -y
+    yum install -y \
+      which \
+      centos-release-scl
+    yum install -y \
+      gcc-c++ \
+      libxml2-devel \
+      libnetfilter_queue-devel
+
+    if [ "$VERSION" != "" ]; then
+        yum install -y git
+        cd $NORM_DIR && git checkout $VERSION && git submodule update --checkout --init --force
+    fi
+
+    if [[ "$WAF_CONFIGURE" =~ "java" && -z `which java` ]]; then
+        yum install -y java-1.8.0-openjdk-devel
+        export JAVA_HOME=$(readlink -f `which java` | sed 's/\/jre\/bin\/java//')
+    fi
+}
+
+configure_norm()
+{
+    cd $NORM_DIR && ./waf configure ${WAF_CONFIGURE}
+}
+
+if [ ! -z `which apt` ]; then
+    install_debian
+elif [ ! -z $(which yum) ] || [ "$?" = "1" ]; then
+    install_redhat
+fi
+configure_norm


### PR DESCRIPTION
Feature proposal in the form of flexible docker image building. At its core, the feature allows customers to spin up docker containers to exercise hands on learning for the NORM example behavior. What's provided in this PR:

- Allows ubuntu and centos container image creation
- Allows `configure` options to piped in to build the Java and Python bindings
- Allows `version` to force the creation of a specific NORM library version
- Update to the README to demonstrate how to build and run the containers