### PR TITLE
wscript: fix build with waf >= 2.1.0

### DIFF
--- a/wscript
+++ b/wscript
@@ -46,7 +46,7 @@ system = platform.system().lower()
 
 def options(ctx):
     ctx.recurse('protolib')    
-    build_opts = ctx.parser.add_option_group('Compile/install Options', 'Use during build/install step.')
+    build_opts = ctx.parser.add_argument_group('Compile/install Options', 'Use during build/install step.')
 
 def configure(ctx):
     ctx.recurse('protolib')


### PR DESCRIPTION
Replace `add_option_group` by `add_argument_group` to a build failure with waf 2.1.0 and https://gitlab.com/ita1024/waf/-/commit/bd5c22d484734f7c1b77e16c91a10c7a44fa6c8a: