### PR TITLE
Some safety fixes

### DIFF
--- a/src/common/normApi.cpp
+++ b/src/common/normApi.cpp
@@ -271,29 +271,12 @@ void NormInstance::Notify(NormController::Event   event,
                     if (NULL != rx_cache_path)
                     {
                         char fileName[PATH_MAX];
-                        strncpy(fileName, rx_cache_path, PATH_MAX);
-                        size_t catMax = strlen(fileName);
-                        if (catMax > PATH_MAX) 
-                            catMax = 0;
-                        else
-                            catMax = PATH_MAX - catMax;
-                        strncat(fileName, "normTempXXXXXX", catMax);
-                        
 #ifdef WIN32
 #ifdef _WIN32_WCE
                         bool tempFileOK = false;
                         for (int i = 0; i < 255; i++)
                         {
-                            strncpy(fileName, rx_cache_path, PATH_MAX);
-                            catMax = strlen(fileName);
-                            if (catMax > PATH_MAX) 
-                                catMax = 0;
-                            else
-                                catMax = PATH_MAX - catMax;
-                            strncat(fileName, "normTempXXXXXX", catMax);
-                            char tempName[16];
-                            sprintf(tempName, "normTemp%06u", i);
-                            strcat(fileName, tempName);
+                            snprintf(fileName, PATH_MAX, "%snormTemp%06u", rx_cache_path, i);
                             if(!NormFile::IsLocked(fileName))
                             {
                                 tempFileOK = true;
@@ -302,9 +285,11 @@ void NormInstance::Notify(NormController::Event   event,
                         }
                         if (!tempFileOK)
 #else
+                        snprintf(fileName, PATH_MAX, "%snormTempXXXXXX", rx_cache_path);
                         if (!_mktemp(fileName))
 #endif // if/else _WIN32_WCE
 #else
+                        snprintf(fileName, PATH_MAX, "%snormTempXXXXXX", rx_cache_path);
                         int fd = mkstemp(fileName); 
                         if (fd >= 0)
                         {

--- a/src/common/normApp.cpp
+++ b/src/common/normApp.cpp
@@ -1718,28 +1718,12 @@ void NormApp::Notify(NormController::Event event,
                         // we can use that for file name right away ???
                         // (TBD) Manage recv file name collisions, etc ...
                         char fileName[PATH_MAX];
-                        strcpy(fileName, rx_cache_path);
-                        size_t catMax = strlen(fileName);
-                        if (catMax > PATH_MAX)
-                            catMax = 0;
-                        else
-                            catMax = PATH_MAX - catMax;
-                        strcat(fileName, "normTempXXXXXX");
 #ifdef WIN32
 #ifdef _WIN32_WCE
                         bool tempFileOK = false;
                         for (int i = 0; i < 255; i++)
                         {
-                            strncpy(fileName, rx_cache_path, PATH_MAX);
-                            catMax = strlen(fileName);
-                            if (catMax > PATH_MAX) 
-                                catMax = 0;
-                            else
-                                catMax = PATH_MAX - catMax;
-                            strncat(fileName, "normTempXXXXXX", catMax);
-                            char tempName[16];
-                            sprintf(tempName, "normTemp%06u", i);
-                            strcat(fileName, tempName);
+                            snprintf(fileName, PATH_MAX, "%snormTemp%06u", rx_cache_path, i);
                             if(!NormFile::IsLocked(fileName))
                             {
                                 tempFileOK = true;
@@ -1748,9 +1732,11 @@ void NormApp::Notify(NormController::Event event,
                         }
                         if (!tempFileOK)
 #else
+                        snprintf(fileName, PATH_MAX, "%snormTempXXXXXX", rx_cache_path);
                         if (!_mktemp(fileName))
 #endif // if/else _WIN32_WCE
 #else
+                        snprintf(fileName, PATH_MAX, "%snormTempXXXXXX", rx_cache_path);
                         int fd = mkstemp(fileName); 
                         if (fd >= 0)
                         {

--- a/src/common/normMessage.cpp
+++ b/src/common/normMessage.cpp
@@ -79,7 +79,7 @@ bool NormMsg::InitFromBuffer(UINT16 msgLength)
             PLOG(PL_FATAL, "NormMsg::InitFromBuffer() invalid message type!\n");
             return false;
     }
-    if (msgLength < header_length)
+    if ((msgLength < header_length) || (header_length < header_length_base))
     {
         PLOG(PL_FATAL, "NormMsg::InitFromBuffer() invalid message or header length\n");
         return false;

--- a/wscript
+++ b/wscript
@@ -47,7 +47,7 @@ system = platform.system().lower()
 
 def options(ctx):
     ctx.recurse('protolib')    
-    build_opts = ctx.parser.add_argument_group('Compile/install Options', 'Use during build/install step.')
+    build_opts = ctx.add_option_group('Compile/install Options', 'Use during build/install step.')
 
     # Add Rust binding options
     ctx.add_option('--build-rust', action='store_true', default=False,


### PR DESCRIPTION
Hello, I ran into a few safety snags while interating norm into a project. Hopefully these are helpful.
  
  - Replaced manual string bounds tracking and concatenation (`strncpy`, `strncat`, `sprintf`) with   
  safe `snprintf` calls in `normApi.cpp` and `normApp.cpp`. This prevents potential buffer overflows and ensures path lengths safely respect `PATH_MAX`.    
  - Added a missing lower-bound validation check in `normMessage.cpp` to verify that `header_length` is at least              
  `header_length_base` before proceeding. This prevents out-of-bounds memory reads on malformed packets.
  - Updated a deprecated `waf` API call (`ctx.parser.add_argument_group` to `ctx.add_option_group`) in `wscript` for     
  compatibility with modern `waf` versions.