### PR TITLE
fix CI builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,15 +17,15 @@ jobs:
       matrix:
         config:
         - {
-            name: "Windows Latest MSVC Shared", artifact: "Windows-MSVC-shared.tar.xz",
-            os: windows-latest,
+            name: "Windows 2022 MSVC Shared", artifact: "Windows-MSVC-shared.tar.xz",
+            os: windows-2022,
             cc: "cl", cxx: "cl",
             shared: "ON",
             environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
           }
         - {
-            name: "Windows Latest MSVC", artifact: "Windows-MSVC.tar.xz",
-            os: windows-latest,
+            name: "Windows 2022 MSVC", artifact: "Windows-MSVC.tar.xz",
+            os: windows-2022,
             cc: "cl", cxx: "cl",
             shared: "OFF",
             environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat"

--- a/src/dotnet/pack-linux-x64.sh
+++ b/src/dotnet/pack-linux-x64.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 currenPath="$PWD"
 cd ../../
+./waf configure
 ./waf
 cd "$currenPath"
 libPath="$currenPath/lib"


### PR DESCRIPTION
This PR fixes the CI builds by pinning MSVC runner configurations to windows-2022 (due to the windows-latest VS 2026 upgrade) and adding a configure step to pack-linux-x64.sh before calling ./waf.